### PR TITLE
[fast,scons] Don't depend on AVX, decide whether to save/restore XMMs or YMMs at instrumentation time

### DIFF
--- a/lib/SConscript
+++ b/lib/SConscript
@@ -27,11 +27,6 @@ import os
 
 Import('env')
 
-# fast speed requires AVX.
-# fast speed implies building both fast and slow
-AddOption('--libspinSpeed', type=str, default='fast')
-assert GetOption('libspinSpeed') in ['fast', 'slow']
-
 includePath = os.path.abspath(os.path.join(Dir('.').srcnode().abspath, '../include/'))
 
 slowEnv = env.Clone()
@@ -40,15 +35,8 @@ slowEnv.Append(CPPDEFINES = 'SPIN_SLOW')
 slowEnv['OBJSUFFIX'] = '.oslow'
 slowlib = slowEnv.StaticLibrary(target='libspin_slow.a', source='spin.cpp')
 
-fastlib = None
-if GetOption('libspinSpeed') == 'fast':
-   fastEnv = env.Clone()
-   fastEnv.Append(CPPPATH = [includePath])
-   # AVX is required by spin-fast; this compiles SNB-compatible code.
-   # To build for an architecture without AVX, use the speed=slow scons option.
-   archFlags = ['-march=corei7-avx', '-mavx', '-msse4.1', '-msse4.2']
-   fastEnv.Append(CPPFLAGS = archFlags)
-
-   fastlib = fastEnv.StaticLibrary(target='libspin_fast.a', source='spin.cpp')
+fastEnv = env.Clone()
+fastEnv.Append(CPPPATH = [includePath])
+fastlib = fastEnv.StaticLibrary(target='libspin_fast.a', source='spin.cpp')
 
 Return('slowlib', 'fastlib')


### PR DESCRIPTION
The goal of this commit is to have one compiled version of libspin that
can run on machines with AVX as well as older machines that lack AVX.

Even if one tries to compile applications/benchmarks without use of AVX,
if the application runs on a machine with AVX, inevitably the C runtime or
some system library code will access the YMM registers.  So if we want
to run libspin on a machine with AVX, we need to support accesses
from userspace to YMMs.  The only way to have one simulator build that
runs on both AVX and non-AVX machines is to dynamically detect whether
the machine has AVX and change our behavior for what registers to
save/restore accordingly.